### PR TITLE
Bug fix, doc, code clean up

### DIFF
--- a/docs/source/api/data.rst
+++ b/docs/source/api/data.rst
@@ -1,0 +1,5 @@
+data
+====
+
+.. automodule:: pyfocal.core.data
+  :members:

--- a/docs/source/custom_loaders.rst
+++ b/docs/source/custom_loaders.rst
@@ -26,11 +26,14 @@ For instance, this built-in YAML definition for Generic FITS below states that::
     author: Nicholas Earl
 
 * Relevant file extensions are either ``.fits`` or ``.mits``.
-* WCS information are in the ``PRIMARY`` (Extension 0) header.
+* WCS information are in the ``PRIMARY`` (Extension 0) header. They will be
+  used to establish dispersion values and unit.
 * Flux values (data) are in Extension 1, the first column (column index starts
-  from 0).
+  from 0). Flux unit is defined by ``BUNIT`` keyword in the same header that
+  contains WCS information.
 * Flux uncertainties are also in Extension 1, the second column. The values are
-  standard deviation (as opposed to variance, ``'ivar'``).
+  standard deviation (as opposed to variance, ``'ivar'``). Its unit must be the
+  same as flux values.
 * The definition file was written by Nicholas Earl.
 
 Meanwhile, this build-in YAML definition for ASCII below states that::
@@ -40,8 +43,10 @@ Meanwhile, this build-in YAML definition for ASCII below states that::
   extension: [txt, dat]
   dispersion:
     col: 0
+    unit: 'Angstrom'
   data:
     col: 1
+    unit: 'erg / (Angstrom cm2 s)'
   uncertainty:
     col: 2
     type: 'std'
@@ -50,10 +55,12 @@ Meanwhile, this build-in YAML definition for ASCII below states that::
 
 * Relevant file extensions are either ``.txt`` or ``.dat``.
 * Dispersion (e.g., wavelength) values are in the first column (column index
-  starts from 0).
-* Flux values (data) are in the second column.
+  starts from 0). Its unit, if not explicitly defined (e.g., via IPAC header),
+  will be set to Angstrom.
+* Flux values (data) are in the second column. Its unit, if not explicitly
+  defined (e.g., via IPAC header), will be set to :math:``.
 * Flux uncertainties are in the third column. The values are standard deviation
-  (as opposed to variance).
+  (as opposed to variance). Its unit must be the same as flux values.
 * The definition file was written by STScI.
 
 To add support for a new file format (e.g., reading spectra from Extension 4

--- a/pyfocal/app.py
+++ b/pyfocal/app.py
@@ -21,7 +21,7 @@ class App(object):
         self.controller = Controller(self.viewer)
 
         if len(argv) > 1:
-            self.controller.read_FITS(sys.argv[1])
+            self.controller.read_file(sys.argv[1])
 
 def setup():
     qapp = QApplication(sys.argv)

--- a/pyfocal/interfaces/default_loaders/ascii.yaml
+++ b/pyfocal/interfaces/default_loaders/ascii.yaml
@@ -3,8 +3,10 @@ name: ASCII
 extension: [txt, dat]
 dispersion:
   col: 0
+  unit: 'Angstrom'
 data:
   col: 1
+  unit: 'erg / (Angstrom cm2 s)'
 uncertainty:
   col: 2
   type: 'std'

--- a/pyfocal/interfaces/factories.py
+++ b/pyfocal/interfaces/factories.py
@@ -1,9 +1,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+# STDLIB
+import logging
+
+# LOCAL
 from ..core.data import Data, Layer, ModelLayer
 from ..core.containers import PlotContainer
 
+# THIRD-PARTY
 import pyqtgraph as pg
 import numpy as np
 from astropy.modeling import models, fitting
@@ -36,7 +41,7 @@ class DataFactory(Factory):
 
     @staticmethod
     def create_layer(data, mask=None, parent=None, window=None, name=''):
-        print("new layer: {}".format(name))
+        logging.info("new layer: {}".format(name))
         mask = mask if mask is not None else np.ones(data.data.shape,
                                                      dtype=bool)
         new_layer = Layer(data, mask, parent, window, name)
@@ -106,7 +111,7 @@ class ModelFactory(Factory):
         if name in cls.all_models:
             return cls.all_models[name]
 
-        print("No such model {}".format(name))
+        logging.error("No such model {}".format(name))
 
 
 class FitterFactory(Factory):
@@ -125,7 +130,7 @@ class FitterFactory(Factory):
         if name in cls.all_fitters:
             return cls.all_fitters[name]
 
-        print("No such fitter {}".format(name))
+        logging.error("No such fitter {}".format(name))
 
 
 class PlotFactory(Factory):

--- a/pyfocal/interfaces/managers.py
+++ b/pyfocal/interfaces/managers.py
@@ -1,12 +1,16 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+# LOCAL
 from .factories import DataFactory, ModelFactory, PlotFactory, FitterFactory
 from ..core.events import EventHook
 from ..analysis import modeling
 from ..third_party.py_expression_eval import Parser
 
+# STDLIB
 import logging
+
+# THIRD-PARTY
 import numpy as np
 
 
@@ -49,12 +53,12 @@ class LayerManager(Manager):
         super(LayerManager, self).__init__()
 
     def new(self, data, mask=None, parent=None, window=None, name=''):
-        print("layer manager: {}".format(name))
+        logging.info("layer manager: {}".format(name))
         new_layer = DataFactory.create_layer(data, mask, parent, window, name)
         return new_layer
 
     def add(self, data, mask=None, parent=None, window=None, name=''):
-        print("layer manager add: {}".format(name))
+        logging.info("layer manager add: {}".format(name))
         new_layer = self.new(data, mask, parent, window, name)
         self._members.append(new_layer)
 
@@ -207,7 +211,7 @@ class ModelLayerManager(Manager):
         del self._members[old_layer]
 
     def update_model(self, model_layer, model_dict, formula=''):
-        print("ModelManager.update_model: {}".format(model_dict))
+        logging.info("ModelManager.update_model: {}".format(model_dict))
         model = self.get_compound_model(model_dict, formula)
         model_layer.model = model
 

--- a/pyfocal/ui/controller.py
+++ b/pyfocal/ui/controller.py
@@ -1,8 +1,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..third_party.qtpy.QtCore import *
+# STDLIB
+import os
 
+# LOCAL
+from ..third_party.qtpy.QtCore import *
 from ..interfaces.managers import (data_manager, layer_manager,
                                    model_layer_manager, plot_manager)
 from ..interfaces.registries import loader_registry
@@ -11,6 +14,7 @@ from ..analysis.modeling import apply_model
 
 
 class Controller(object):
+    """GUI controller."""
     def __init__(self, viewer):
         # Controller-specific events
         self.viewer = viewer
@@ -157,9 +161,9 @@ class Controller(object):
 
         self.viewer.update_statistics(stat_dict)
 
-    def read_FITS(self, FITS_file_name):
+    def read_file(self, file_name):
         """
-        Convenience method that directly reads a spectrum from a FITS file.
+        Convenience method that directly reads a spectrum from a file.
         This exists mostly to facilitate development workflow. In time it
         could be augmented to support fancier features such as wildcards,
         file lists, mixed file types, and the like.
@@ -167,7 +171,15 @@ class Controller(object):
         depend on the intrincacies of the registries, loaders, and data
         classes. In other words, this is brittle code.
         """
-        data = data_manager.load(str(FITS_file_name), 'Generic Fits (*.fits *.mits)')
+        file_name = str(file_name)
+        file_ext = os.path.splitext(file_name)[-1]
+
+        if file_ext in ('.txt', '.dat'):
+            file_filter = 'ASCII (*.txt *.dat)'
+        else:
+            file_filter = 'Generic Fits (*.fits *.mits)'
+
+        data = data_manager.load(file_name, file_filter)
         self.viewer.add_data_item(data)
 
     def open_file(self, file_name=None):


### PR DESCRIPTION
Changes include:

* Fixes #46 which requires
    * Unit assumptions for ASCII data when units are not explicitly set (say, by IPAC).
    *  Loaders to auto set flux uncertainty to zeroes (instead of `None`) when data has no uncertainty column to avoid crashing down the line.
* Updated doc for custom loader to reflect code changes.
* Added API doc for `core.data` module.
* `pyfocal filename` can how handle both FITS and ASCII sys arg input. Still no wildcard support.
* Replace some `print()` functions with more elegant logging calls.