### PR TITLE
Add "Known Issues" section with workaround for qt4/qt5 error

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,7 +2,7 @@ Dependencies
 ------------
 
 In the future, Pyfocal will be distributed through package managers like
-Anaconda and Homebrew that will obviate the need for manual installation from
+`Anaconda <https://anaconda.org>`_ and `Homebrew <http://brew.sh>`_ that will obviate the need for manual installation from
 source. Most of these will be handled automatically by the setup functions,
 with the exception of ``PyQt``/``PySide``.
 
@@ -95,3 +95,19 @@ launched from the command line::
 
 Again, if you're using an Anaconda virtual environment, please be sure to
 activate it before launching Pyfocal.
+
+
+Known Issues
+------------
+
+On a Mac with Qt5, depending on exactly how you have set up Anaconda, you might see the following error after following the above instructions::
+
+    This application failed to start because it could not find or load the Qt platform plugin "cocoa".
+
+    Reinstalling the application may fix this problem.
+
+If you see this message, you have encountered an incompatibility between Anaconda's packaging of Qt4 and Qt5.  The workaround is to uninstall Qt4 with the following command::
+
+    $ conda uninstall pyqt qt
+
+and pyfocal should now happily run.


### PR DESCRIPTION
This adds a "Known Issues" section to the installation docs with a quick fix for the "this application failed to start because it could not find or load the Qt platform plugin "cocoa"." error